### PR TITLE
add one click deploy to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Search, create, update, and delete data entries using a convenient UI. Create co
 
 ## Deployment
 
+### Dome
+[![Deploy to Dome](https://trydome.io/button.svg)](https://app.trydome.io/signup?package=motor-admin)
+
 ### Heroku
 
 [![Deploy to Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/motor-admin/motor-admin-heroku)


### PR DESCRIPTION
Hey!

We built this one-click deploy link for your users who may not know how to stand up their own infrastructure to easily self-host this.

After deployment, users receive a link like this, which can then be CNAME-ed to any domain:

https://motoradmin-1132.dome.tools

Take it for a test run—we're eager to receive your feedback! We're more than willing to maintain this for the long haul, if this is valuable for your users.